### PR TITLE
尝试添加北航盘上传（未测试）

### DIFF
--- a/judger/src/fs/net.rs
+++ b/judger/src/fs/net.rs
@@ -129,10 +129,10 @@ pub async fn git_clone(dir: &Path, options: GitCloneOptions) -> std::io::Result<
             // TODO: write command for macos
         }
         else {
-            do_command!(dir, [&("x=`curl --location --request POST 'https://bhpan.buaa.edu.cn/api/v1/link/osdownload' --header 'Content-Type: application/json' --data-raw '{\"link\":\"".to_string()
+            do_command!(dir, ["sh", &("x=`curl --location --request POST 'https://bhpan.buaa.edu.cn/api/v1/link/osdownload' --header 'Content-Type: application/json' --data-raw '{\"link\":\"".to_string()
             + fid 
             + "\",\"reqhost\":\"bhpan.buaa.edu.cn\",\"usehttps\": true}'`&&x=`echo ${x%\\\"]*}`&&x=`echo ${x#*,\\\"}`&&curl --location --request GET $x --output code.zip"
-            ),]);
+            )]);
             do_command!(dir, ["unzip", "code.zip"]);
         }
         Ok(())

--- a/judger/src/fs/net.rs
+++ b/judger/src/fs/net.rs
@@ -108,6 +108,36 @@ pub async fn git_clone(dir: &Path, options: GitCloneOptions) -> std::io::Result<
 
     tokio::fs::create_dir_all(dir).await?;
 
+    if &options.revision == "bhpan" {
+        let bytes =  &options.repo.as_bytes();
+
+        // cut 'https://bhpan.buaa.edu.cn/link/'
+        let mut fid = &options.repo[35..];
+
+        for (i, &item) in bytes.iter().enumerate() {
+            if item == b'#'{
+                // cut 'https://bhpan.buaa.edu.cn/#/link/', if so
+                fid = &options.repo[37..];
+                break;
+            }
+        }
+
+        if cfg!(windows) {
+            // TODO: write command for windows
+        }
+        else if cfg!(macos) {
+            // TODO: write command for macos
+        }
+        else {
+            do_command!(dir, [&("x=`curl --location --request POST 'https://bhpan.buaa.edu.cn/api/v1/link/osdownload' --header 'Content-Type: application/json' --data-raw '{\"link\":\"".to_string()
+            + fid 
+            + "\",\"reqhost\":\"bhpan.buaa.edu.cn\",\"usehttps\": true}'`&&x=`echo ${x%\\\"]*}`&&x=`echo ${x#*,\\\"}`&&curl --location --request GET $x --output code.zip"
+            ),]);
+            do_command!(dir, ["unzip", "code.zip"]);
+        }
+        Ok(())
+    }
+
     do_command!(dir, ["git", "init"]);
     do_command!(dir, ["git", "remote", "add", "origin", &options.repo]);
     do_command!(


### PR DESCRIPTION
修改 `judger/src/fs/net.rs`，将原通过 git 获取代码的函数增加一个 if，如果 branch 名为 `bhpan`，那么将 repo 地址视为通过北航盘分享的zip文件的链接，通过 curl 下载，并解压到当前 job 工作目录。

例如，被分享的文件链接为，`https://bhpan.buaa.edu.cn/link/114E514` 或者 `https://bhpan.buaa.edu.cn/#/link/114E514`，首先通过截取字符串获得源文件真实的 id ，即`fid = "114E514"`。随后调用已有的 `do_command!()`，打开 sh，并传入一个被压缩成一句的指令 
```bash
x=`curl --location --request POST 'https://bhpan.buaa.edu.cn/api/v1/link/osdownload' --header 'Content-Type: application/json' --data-raw '{\"link\":\"114E514\",\"reqhost\":\"bhpan.buaa.edu.cn\",\"usehttps\": true}'`&&x=`echo ${x%\\\"]*}`&&x=`echo ${x#*,\\\"}`&&curl --location --request GET $x --output code.zip
```
该指令成功执行后会将被分享的文件下载为 `code.zip`。随后继续调用 `do_command!()` 通过 `unzip` 将其解压到工作目录，函数返回，达到了和通过 git 获取代码同样的效果。