### PR TITLE
fix: fix `NotRan` typo

### DIFF
--- a/coordinator/Model/TestSuite.cs
+++ b/coordinator/Model/TestSuite.cs
@@ -155,7 +155,7 @@ namespace Karenia.Rurikawa.Models.Test {
         TimeLimitExceeded = 4,
         MemoryLimitExceeded = 5,
         ShouldFail = 6,
-        NotRan = -1,
+        NotRun = -1,
         Waiting = -2,
         Running = -3,
         OtherError = -100,

--- a/docs/manual/results.md
+++ b/docs/manual/results.md
@@ -34,5 +34,5 @@
 | PF   | PipelineFailed      | 运行时有某一步输出不为 0             |
 | TLE  | TimeLimitExceeded   | 超时了                               |
 | MLE  | MemoryLimitExceeded | 占用内存过大                         |
-| NR   | NotRan              | 没有运行                             |
+| NR   | NotRun              | 没有运行                             |
 | OE   | OtherError          | 出现了其他错误（通常是评测机的问题） |

--- a/judger/src/client/model.rs
+++ b/judger/src/client/model.rs
@@ -100,7 +100,7 @@ pub enum TestResultKind {
     TimeLimitExceeded = 4,
     MemoryLimitExceeded = 5,
     ShouldFail = 6,
-    NotRan = -1,
+    NotRun = -1,
     Waiting = -2,
     Running = -3,
     OtherError = -100,
@@ -203,7 +203,7 @@ pub async fn transform_and_upload_test_result(
                 Some("The tested program should return a non-zero number at some point".into()),
                 None,
             ),
-            JobFailure::Cancelled => (TestResultKind::NotRan, None, None),
+            JobFailure::Cancelled => (TestResultKind::NotRun, None, None),
         },
     };
 

--- a/web/src/components/item-components/job-test-item/job-test-item.component.ts
+++ b/web/src/components/item-components/job-test-item/job-test-item.component.ts
@@ -26,7 +26,7 @@ export class JobTestItemComponent implements OnInit {
         return 'AC';
       case 'MemoryLimitExceeded':
         return 'MLE';
-      case 'NotRan':
+      case 'NotRun':
         return 'NR';
       case 'OtherError':
         return 'OE';

--- a/web/src/models/job-items.ts
+++ b/web/src/models/job-items.ts
@@ -13,7 +13,7 @@ export function dashboardTypeToSlider(item: TestResultKind): SliderItemKind {
       return 'error';
     case 'MemoryLimitExceeded':
       return 'warn';
-    case 'NotRan':
+    case 'NotRun':
       return 'cancel';
     case 'OtherError':
       return 'info-alt';
@@ -104,7 +104,7 @@ export type TestResultKind =
   | 'TimeLimitExceeded'
   | 'MemoryLimitExceeded'
   | 'ShouldFail'
-  | 'NotRan'
+  | 'NotRun'
   | 'Waiting'
   | 'Running'
   | 'OtherError';


### PR DESCRIPTION
这里曾经也经过了改动：NotRunned -> NotRan，即认为此处的标识是 not+动词过去式的形式。

我查阅了相关英文语法，我认为此处应当是 It is not done. (not+动词过去分词) 的形式，使用到的是被动语态。即我认为应将其修改为run的过去分词形式run，即NotRun。

举例：

- It is done. (语法正确)
- It is not done. (语法正确)
- It is did. (语法错误)

参考：[被动语态怎么用？](https://www.zhihu.com/question/296080933/answer/500058068) 主语+be动词+及物动词过去分词+(by+动作发出者)
